### PR TITLE
Add 'announce' option to Provide

### DIFF
--- a/routing.go
+++ b/routing.go
@@ -17,8 +17,10 @@ var ErrNotFound = errors.New("routing: not found")
 // ContentRouting is a value provider layer of indirection. It is used to find
 // information about who has what content.
 type ContentRouting interface {
-	// Announce that this node can provide value for given key
-	Provide(context.Context, *cid.Cid) error
+	// Provide adds the given cid to the content routing system. If 'true' is
+	// passed, it also announces it, otherwise it is just kept in the local
+	// accounting of which objects are being provided.
+	Provide(context.Context, *cid.Cid, bool) error
 
 	// Search for peers who are able to provide a given key
 	FindProvidersAsync(context.Context, *cid.Cid, int) <-chan pstore.PeerInfo


### PR DESCRIPTION
Add an option to provide that allows the called to decide whether or not
to broadcast the provider information to the network or just keep it
locally. Provides kept locally will still be discoverable if asked
directly, but will not send out to other peers.