### PR TITLE
make closing the query events channel safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 install:
   - make deps

--- a/notifications/query.go
+++ b/notifications/query.go
@@ -88,12 +88,12 @@ func PublishQueryEvent(ctx context.Context, ev *QueryEvent) {
 }
 
 func (qe *QueryEvent) MarshalJSON() ([]byte, error) {
-	out := make(map[string]interface{})
-	out["ID"] = peer.IDB58Encode(qe.ID)
-	out["Type"] = int(qe.Type)
-	out["Responses"] = qe.Responses
-	out["Extra"] = qe.Extra
-	return json.Marshal(out)
+	return json.Marshal(map[string]interface{}{
+		"ID":        peer.IDB58Encode(qe.ID),
+		"Type":      int(qe.Type),
+		"Responses": qe.Responses,
+		"Extra":     qe.Extra,
+	})
 }
 
 func (qe *QueryEvent) UnmarshalJSON(b []byte) error {

--- a/notifications/query.go
+++ b/notifications/query.go
@@ -3,14 +3,16 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 )
 
-const RoutingQueryKey = "RoutingQueryEvent"
-
 type QueryEventType int
+
+// Number of events to buffer.
+var QueryEventBufferSize = 16
 
 const (
 	SendingQuery QueryEventType = iota
@@ -30,25 +32,59 @@ type QueryEvent struct {
 	Extra     string
 }
 
-func RegisterForQueryEvents(ctx context.Context, ch chan<- *QueryEvent) context.Context {
-	return context.WithValue(ctx, RoutingQueryKey, ch)
+type routingQueryKey struct{}
+type eventChannel struct {
+	mu  sync.Mutex
+	ctx context.Context
+	ch  chan<- *QueryEvent
+}
+
+// waitThenClose is spawned in a goroutine when the channel is registered. This
+// safely cleans up the channel when the context has been canceled.
+func (e *eventChannel) waitThenClose() {
+	<-e.ctx.Done()
+	e.mu.Lock()
+	close(e.ch)
+	// 1. Signals that we're done.
+	// 2. Frees memory (in case we end up hanging on to this for a while).
+	e.ch = nil
+	e.mu.Unlock()
+}
+
+// send sends an event on the event channel, aborting if either the passed or
+// the internal context expire.
+func (e *eventChannel) send(ctx context.Context, ev *QueryEvent) {
+	e.mu.Lock()
+	// Closed.
+	if e.ch == nil {
+		e.mu.Unlock()
+		return
+	}
+	// in case the passed context is unrelated, wait on both.
+	select {
+	case e.ch <- ev:
+	case <-e.ctx.Done():
+	case <-ctx.Done():
+	}
+	e.mu.Unlock()
+}
+
+func RegisterForQueryEvents(ctx context.Context) (context.Context, <-chan *QueryEvent) {
+	ch := make(chan *QueryEvent, QueryEventBufferSize)
+	ech := &eventChannel{ch: ch, ctx: ctx}
+	go ech.waitThenClose()
+	return context.WithValue(ctx, routingQueryKey{}, ech), ch
 }
 
 func PublishQueryEvent(ctx context.Context, ev *QueryEvent) {
-	ich := ctx.Value(RoutingQueryKey)
+	ich := ctx.Value(routingQueryKey{})
 	if ich == nil {
 		return
 	}
 
-	ch, ok := ich.(chan<- *QueryEvent)
-	if !ok {
-		return
-	}
-
-	select {
-	case ch <- ev:
-	case <-ctx.Done():
-	}
+	// We *want* to panic here.
+	ech := ich.(*eventChannel)
+	ech.send(ctx, ev)
 }
 
 func (qe *QueryEvent) MarshalJSON() ([]byte, error) {

--- a/notifications/query_test.go
+++ b/notifications/query_test.go
@@ -1,0 +1,44 @@
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestEventsCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, events := RegisterForQueryEvents(ctx)
+	goch := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			PublishQueryEvent(ctx, &QueryEvent{Extra: fmt.Sprint(i)})
+		}
+		close(goch)
+		for i := 100; i < 1000; i++ {
+			PublishQueryEvent(ctx, &QueryEvent{Extra: fmt.Sprint(i)})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		i := 0
+		for e := range events {
+			if i < 100 {
+				if e.Extra != fmt.Sprint(i) {
+					t.Errorf("expected %d, got %s", i, e.Extra)
+				}
+			}
+			i++
+		}
+		if i < 100 {
+			t.Errorf("expected at least 100 events, got %d", i)
+		}
+	}()
+	<-goch
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
fixes https://github.com/ipfs/go-ipfs/issues/5616

Basically, we need to be able to close and write to the channel under the same lock. With this change, we can manage the channel with the context itself.