### PR TITLE
WIP: Change ContentRouting interface to work with Multihash's not CIDs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7",
-      "name": "go-cid",
-      "version": "0.9.0"
-    },
-    {
-      "author": "whyrusleeping",
       "hash": "QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W",
       "name": "go-libp2p-peer",
       "version": "2.3.7"
+    },
+    {
+      "author": "multiformats",
+      "hash": "QmPnFwZ2JXKnXgMw8CdBPxn7FWh6LLdjUjxV1fKHuJnkr8",
+      "name": "go-multihash",
+      "version": "1.0.8"
     }
   ],
   "gxVersion": "0.4.0",

--- a/routing.go
+++ b/routing.go
@@ -7,10 +7,10 @@ import (
 
 	ropts "github.com/libp2p/go-libp2p-routing/options"
 
-	cid "github.com/ipfs/go-cid"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	mh "github.com/multiformats/go-multihash"
 )
 
 // ErrNotFound is returned when the router fails to find the requested record.
@@ -26,10 +26,10 @@ type ContentRouting interface {
 	// Provide adds the given cid to the content routing system. If 'true' is
 	// passed, it also announces it, otherwise it is just kept in the local
 	// accounting of which objects are being provided.
-	Provide(context.Context, cid.Cid, bool) error
+	Provide(context.Context, mh.Multihash, bool) error
 
 	// Search for peers who are able to provide a given key
-	FindProvidersAsync(context.Context, cid.Cid, int) <-chan pstore.PeerInfo
+	FindProvidersAsync(context.Context, mh.Multihash, int) <-chan pstore.PeerInfo
 }
 
 // PeerRouting is a way to find information about certain peers.


### PR DESCRIPTION
Required once the blockstores works with Multihashes insead of CIDs. See https://github.com/ipfs/go-ipfs/pull/5510#issuecomment-430386610 for justification.

Also see #32.

